### PR TITLE
fix(workflow): update GITHUB_TOKEN references for consistency

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -54,6 +54,8 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git
 
       - name: Create and Push Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           new_version=${{ steps.increment_version.outputs.new_version }}
           git tag "v$new_version"
@@ -61,6 +63,8 @@ jobs:
 
       - name: Update VERSION file (if version was incremented)
         if: steps.check_tag.outputs.use_tag == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           new_version=${{ steps.increment_version.outputs.new_version }}
           echo $new_version > VERSION
@@ -102,10 +106,10 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         with:
-          tag_name: "v${{ steps.increment_version.outputs.new_version }}"
-          release_name: "Release v${{ steps.increment_version.outputs.new_version }}"
+          tag_name: "v${{ needs.tag.outputs.new_version }}"
+          release_name: "Release v${{ needs.tag.outputs.new_version }}"
           body: |
             Changes in this release:
             - TODO: Add release notes here


### PR DESCRIPTION
- Added `GITHUB_TOKEN` environment variable to the "Create and Push Tag" and "Update VERSION file" steps to ensure consistent authentication.
- Changed `GITHUB_TOKEN` reference in the "Create Release" step to use `${{ secrets.PAT_TOKEN }}` for uniformity.
- Modified `tag_name` and `release_name` in "Create Release" step to use outputs from the "tag" job for accuracy.