### PR TITLE
ci: exclude specific paths from triggering workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**[skip ci]'
   pull_request:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**[skip ci]'
 
 jobs:
   test:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**[skip ci]'
 
 jobs:
   tag:
@@ -63,7 +65,7 @@ jobs:
         run: |
           echo $new_version > VERSION
           git add VERSION
-          git commit -m "Bump version to $new_version"
+          git commit -m "Bump version to $new_version [skip ci]"
           git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git main
 
   release:


### PR DESCRIPTION
Added '**[skip ci]' to paths-ignore in workflows to prevent unnecessary CI runs on non-code changes. This helps in reducing unnecessary usage of CI resources and speeds up the overall development process. Also, updated version bump commit message to include [skip ci] to prevent triggering CI on version bumps.