### PR TITLE
fix(workflow): correct version handling logic in tag-and-release.yml

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -35,7 +35,8 @@ jobs:
             echo "use_tag=true" >> $GITHUB_ENV
           else
             echo "use_tag=false" >> $GITHUB_ENV
-            echo "new_version=$VERSION" >> $GITHUB_ENV # Set new_version to VERSION
+            echo "new_version=$VERSION" >> $GITHUB_ENV
+          fi
 
       - name: Increment version if necessary
         id: increment_version


### PR DESCRIPTION
Ensure `use_tag` and `new_version` are set correctly when incrementing the version. This fixes an issue where the version increment step was not executed due to a missing `fi` statement.