### PR TITLE
fix(workflow): improve tag existence check in release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check if the current version is already tagged
         id: check_tag
         run: |
-          if git rev-parse -q --verify "refs/tags/v${{ env.VERSION }}"; then
+          if git tag --list "v${{ env.VERSION }}"; then
             echo "Tag v${{ env.VERSION }} already exists."
             echo "TAG_EXISTS=true" >> $GITHUB_ENV
           else


### PR DESCRIPTION
Updated the tag existence check in the GitHub Actions workflow to use `git tag --list` instead of `git rev-parse`. This simplifies the verification process and improves readability.