### PR TITLE
feat(workflow): add prerelease determination for version tagging

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -13,6 +13,7 @@ jobs:
 
     outputs:
       new_version: ${{ steps.set_new_version.outputs.new_version }}
+      prerelease: ${{ steps.set_prerelease.outputs.prerelease }}
 
     steps:
       - name: Checkout code
@@ -41,6 +42,18 @@ jobs:
           echo "Incrementing version to $NEW_VERSION"
           echo "::set-output name=new_version::$NEW_VERSION"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Determine if Prerelease
+        id: set_prerelease
+        run: |
+          IFS='.' read -r major minor patch <<< "$NEW_VERSION"
+          if [ "$major" -eq 0 ]; then
+            echo "Setting prerelease to true for $NEW_VERSION"
+            echo "::set-output name=prerelease::true"
+          else
+            echo "Setting prerelease to false for $NEW_VERSION"
+            echo "::set-output name=prerelease::false"
+          fi
 
       - name: Update VERSION file
         run: |
@@ -107,4 +120,4 @@ jobs:
             Changes in this release:
             - TODO: Add release notes here
           draft: false
-          prerelease: false
+          prerelease: ${{ needs.tag.outputs.prerelease }}


### PR DESCRIPTION
- Added a step to determine if the new version is a prerelease.
- Outputs 'prerelease' flag based on the major version number.
- Updates release creation step to use the determined 'prerelease' flag.
- Helps in distinguishing between stable and prerelease versions.