### PR TITLE
feat(workflow): integrate Release Drafter for automated release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,13 @@
+name: Release Drafter
+tag-template: v$NEW_VERSION
+categories:
+  - title: '🚀 Features'
+    labels: ['feature']
+  - title: '🐛 Bug Fixes'
+    labels: ['bug']
+  - title: '🛠 Maintenance'
+    labels: ['chore', 'refactor']
+change-template: '- ${{PR.title}} (#${{PR.number}}) by @${{PR.author}}'
+template: |
+  ## What's Changed
+  $CHANGES

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -110,7 +110,15 @@ jobs:
       - name: Run tests
         run: go test -v ./...
 
-      - name: Create Release
+      - name: Use Release Drafter
+        id: draft_release
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ needs.tag.outputs.new_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+      - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -118,8 +126,6 @@ jobs:
         with:
           tag_name: "v${{ needs.tag.outputs.new_version }}"
           release_name: "Release v${{ needs.tag.outputs.new_version }}"
-          body: |
-            Changes in this release:
-            - TODO: Add release notes here
+          body: ${{ steps.draft_release.outputs.body }}
           draft: false
           prerelease: ${{ needs.tag.outputs.prerelease }}


### PR DESCRIPTION
- Added Release Drafter step in GitHub Actions workflow to automate release note generation.
- Updated `tag-and-release.yml` to use Release Drafter for creating GitHub releases.
- Introduced `.github/release-drafter.yml` to configure release notes categories and templates.
- Benefits include streamlined release process and consistent release notes, enhancing project maintainability.