### PR TITLE
fix(router): prevent group creation for empty prefixes

### DIFF
--- a/hostroute.go
+++ b/hostroute.go
@@ -48,8 +48,10 @@ func SetupHostBasedRoutes(r *gin.Engine, hostConfigs []HostConfig, genericHosts 
 		hostConfigs[i].engine = engine
 		hostConfigs[i].RouterFactory(&engine.RouterGroup)
 
-		group := r.Group(fmt.Sprintf("/%s", hostConfigs[i].Prefix))
-		hostConfigs[i].RouterFactory(group)
+		if hostConfigs[i].Prefix != "" {
+			group := r.Group(fmt.Sprintf("/%s", hostConfigs[i].Prefix))
+			hostConfigs[i].RouterFactory(group)
+		}
 
 		hostConfigMap[hostConfigs[i].Host] = &hostConfigs[i]
 	}


### PR DESCRIPTION
Ensure that groups are not created when the prefix is an empty string. This avoids unnecessary route groups and potential routing issues.