### PR TITLE
fix(README): correct test status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A high-performance Gin middleware library for routing based on the host. This library facilitates the configuration of different routes and behaviors for distinct hostnames, enhancing the ability to host multi-tenant applications on a single server.
 
 [![go report card](https://goreportcard.com/badge/github.com/YidiDev/gin-host-route "go report card")](https://goreportcard.com/report/github.com/YidiDev/gin-host-route)
-[![test status](https://github.com/YidiDev/gin-host-route/.github/workflows/tests/badge.svg?branch=main "test status")](https://github.com/YidiDev/gin-host-route/actions)
+[![test status](https://github.com/YidiDev/gin-host-route/workflows/tests/badge.svg?branch=main "test status")](https://github.com/YidiDev/gin-host-route/actions)
 [![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-blue?logo=go&logoColor=white)](https://pkg.go.dev/github.com/YidiDev/gin-host-route?tab=doc)
 


### PR DESCRIPTION
Updated the URL for the test status badge in the README to ensure it correctly reflects the build status. This improves the accuracy of the project's status representation and enhances developer confidence.