### PR TITLE
refactor(workflows): split release workflow into update draft and cre…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Tag and Release
+name: Create Release
 
 on:
   push:
@@ -18,16 +18,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up GitHub Actions settings
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
 
-      - name: Auto-generate Release Notes
-        id: generate_release_notes
+      - name: Generate Release Notes for Tag
         uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-draft-release.yml
+++ b/.github/workflows/update-draft-release.yml
@@ -1,0 +1,30 @@
+name: Update Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+jobs:
+  update_draft_release:
+    name: Update Draft Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up GitHub Actions settings
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+
+      - name: Auto-generate Release Notes
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…ate release

This commit refactors the GitHub Actions workflows by removing the previous `release-on-tag.yml` and introducing two new workflows: `update-draft-release.yml` and `create-release.yml`.

The `update-draft-release.yml` workflow updates draft releases on pushes to the main branch, allowing continuous integration of changes into draft release notes.

The `create-release.yml` workflow triggers on new tags, ensuring that releases are created with up-to-date notes.

This separation enhances clarity and maintainability of release processes.