### PR TITLE
chore(release-drafter): add 'Uncategorized' section to draft config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,8 @@
 name-template: 'Release ${{ version }}'
 tag-template: '${{ version }}'
 categories:
+  - title: 'Uncategorized'
+    label: ''
   - title: 'New Features'
     labels: ['feature']
   - title: 'Bug Fixes'


### PR DESCRIPTION
Added an 'Uncategorized' section in the release drafter configuration to ensure that changes without specific labels are still categorized in release notes. This helps maintain clarity and organization in tracking changes that do not fit into predefined categories.