### PR TITLE
feat(workflow): add auto-labeler for unlabeled issues and PRs

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,27 @@
+name: Auto Label Unlabeled Issues
+on:
+  issues:
+    types: [opened, reopened, edited]
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup GitHub CLI
+        uses: actions/setup-node@v4
+
+      - name: Add misc label to unlabeled issues or PRs
+        run: |
+          gh issue list --json number,labels --label '' | jq -c '.[] | select(.labels | length == 0) | .number' | xargs -I {} gh issue edit {} --add-label "misc"
+          gh pr list --json number,labels | jq -c '.[] | select(.labels | length == 0) | .number' | xargs -I {} gh pr edit {} --add-label "misc"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automatically add a "misc" label to newly opened, reopened, or edited issues and pull requests that lack any labels. This helps in organizing and categorizing unlabeled items, ensuring better tracking and management of issues and PRs.