### PR TITLE
feat(workflow): enforce labeling on pull requests

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,0 +1,26 @@
+name: Label Check
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label_check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for Labels
+        run: |
+          labels=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                        -H "Accept: application/vnd.github.v3+json" \
+                        "${{ github.event.pull_request.url }}/labels" \
+                        | jq '. | length')
+          if [ "$labels" -eq "0" ]; then
+            echo "Error: PR must have at least one label."
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a GitHub Actions workflow to ensure that all pull requests have at least one label before merging. This helps in organizing and categorizing PRs, making it easier for maintainers to manage the repository effectively. The workflow triggers on PR events such as opened, reopened, labeled, unlabeled, and synchronize.